### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![vimtronner][game_play_img]
 
-#vimtronner
+# vimtronner
 
 A multiplayer, realtime, command-line game that teaches you the core
 vim keys. Be the last player alive by either controlling your bike


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
